### PR TITLE
Fix cpp flags on macos.

### DIFF
--- a/chiphunk.cabal
+++ b/chiphunk.cabal
@@ -118,3 +118,6 @@ library
     , vector-space >=0.13 && <0.16
   default-language: Haskell2010
   build-tool-depends: c2hs:c2hs >= 0.28.1 && < 0.29
+  if os(darwin)
+    cpp-options: -D__attribute__(X)= -D_Null_unspecified= -D__asm(X)=
+                 -U__has_extension -DCP_USE_CGTYPES=0

--- a/package.yaml
+++ b/package.yaml
@@ -75,6 +75,14 @@ library:
   - safe-exceptions >= 0.1.7.0 && < 0.2
   - hashable >= 1.2.6.0 && < 1.3
 
+  when:
+  - condition: os(darwin)
+    then:
+      cpp-options: |
+        -D__attribute__(X)= -D_Null_unspecified= -D__asm(X)=
+        -U__has_extension -DCP_USE_CGTYPES=0
+    else: {}
+
   verbatim:
     build-tool-depends: |
       c2hs:c2hs >= 0.28.1 && < 0.29


### PR DESCRIPTION
c2hs chokes on macos headers until we disable a bunch of stuff.