### PR TITLE
Fix compile on modern Linux by cherry-picking slembcke/Chipmunk2D#175

### DIFF
--- a/Chipmunk2D-7.0.2/src/cpHastySpace.c
+++ b/Chipmunk2D-7.0.2/src/cpHastySpace.c
@@ -7,8 +7,12 @@
 //TODO: Move all the thread stuff to another file
 
 //#include <sys/param.h >
-#ifndef _WIN32
+
+#ifdef __APPLE__
 #include <sys/sysctl.h>
+#endif
+
+#ifndef _WIN32
 #include <pthread.h>
 #else
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
sysctl on Linux is no more:
https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=076f09afbac1aa57756faa7a8feadb7936a724e4

Chipmunk2D doesn't use it on this platform anyway.